### PR TITLE
Added parameter for keeping labels in original position

### DIFF
--- a/TGPControls/TGPCamelLabels7.h
+++ b/TGPControls/TGPCamelLabels7.h
@@ -48,4 +48,6 @@
 @property (nonatomic, strong) NSArray * names; // Will dictate the number of ticks
 @property (nonatomic, assign) NSTimeInterval animationDuration;
 
+@property (nonatomic, assign) BOOL animate; // Make the labels animate when selected
+
 @end

--- a/TGPControls/TGPCamelLabels7.m
+++ b/TGPControls/TGPCamelLabels7.m
@@ -155,6 +155,8 @@
 
     _lastValue = NSNotFound;    // Never tapped
     _animationDuration = 0.15;
+    
+    _animate = YES;
 
     [self layoutTrack];
 }
@@ -262,7 +264,7 @@
 
     if(duration > 0) {
         [UIView animateWithDuration:duration
-                        delay:0
+                              delay:0
                             options:(UIViewAnimationOptionBeginFromCurrentState +
                                      UIViewAnimationOptionCurveLinear)
                          animations:moveBlock
@@ -274,21 +276,25 @@
 
 - (void)moveDown:(UIView*)aView withAlpha:(CGFloat) alpha
 {
-    aView.frame = ({
-        CGRect frame = aView.frame;
-        frame.origin.y = self.bounds.size.height - frame.size.height;
-        frame;
-    });
+    if (self.animate) {
+        aView.frame = ({
+            CGRect frame = aView.frame;
+            frame.origin.y = self.bounds.size.height - frame.size.height;
+            frame;
+        });
+    }
     [aView setAlpha:alpha];
 }
 
 - (void)moveUp:(UIView*)aView withAlpha:(CGFloat) alpha
 {
-    aView.frame = ({
-        CGRect frame = aView.frame;
-        frame.origin.y = 0;
-        frame;
-    });
+    if (self.animate) {
+        aView.frame = ({
+            CGRect frame = aView.frame;
+            frame.origin.y = 0;
+            frame;
+        });
+    }
     [aView setAlpha:alpha];
 }
 


### PR DESCRIPTION
The parameter `animate` was added to prevent labels from animating
up and down when a selection is made. The animation between the up
and down label themselves (font and color) is kept as is.