### PR TITLE
Flexible alignment of end labels

### DIFF
--- a/TGPControls/TGPCamelLabels7.h
+++ b/TGPControls/TGPCamelLabels7.h
@@ -50,4 +50,9 @@
 
 @property (nonatomic, assign) BOOL animate; // Make the labels animate when selected
 
+// If false first and last label will align left (first label) and right (last label).
+@property (nonatomic, assign) BOOL centerEndLabels;
+// Margin to the left and right of the slider. Only relevant if centerEndLabel is false.
+@property (nonatomic, assign) NSInteger horizontalMargin;
+
 @end

--- a/TGPControls/TGPCamelLabels7.m
+++ b/TGPControls/TGPCamelLabels7.m
@@ -157,6 +157,8 @@
     _animationDuration = 0.15;
     
     _animate = YES;
+    _centerEndLabels = YES;
+    _horizontalMargin = nil;
 
     [self layoutTrack];
 }
@@ -184,6 +186,7 @@
     if( count > 0) {
         CGFloat centerX = (self.bounds.size.width - ((count - 1) * self.ticksDistance))/2.0;
         const CGFloat centerY = self.bounds.size.height / 2.0;
+        int i = 0;
         for(NSString * name in self.names) {
             UILabel * upLabel = [[UILabel alloc] initWithFrame:CGRectZero];
             [self.upLabels addObject:upLabel];
@@ -200,6 +203,13 @@
                 CGRect frame = upLabel.frame;
                 // frame.origin.y = 0;
                 frame.origin.y = self.bounds.size.height - frame.size.height;
+                if(!self.centerEndLabels) {
+                    if(i == 0) {
+                        frame.origin.x = self.horizontalMargin;
+                    } else if(i == count - 1) {
+                        frame.origin.x = self.bounds.size.width - (upLabel.frame.size.width + self.horizontalMargin);
+                    }
+                }
                 frame;
             });
             upLabel.alpha = 0.0;
@@ -219,11 +229,19 @@
             dnLabel.frame = ({
                 CGRect frame = dnLabel.frame;
                 frame.origin.y = self.bounds.size.height - frame.size.height;
+                if(!self.centerEndLabels) {
+                    if(i == 0) {
+                        frame.origin.x = self.horizontalMargin;
+                    } else if(i == count - 1) {
+                        frame.origin.x = self.bounds.size.width - (dnLabel.frame.size.width + self.horizontalMargin);
+                    }
+                }
                 frame;
             });
             [self addSubview:dnLabel];
 
             centerX += self.ticksDistance;
+            i++;
         }
         [self dockEffect:0.0];
     }


### PR DESCRIPTION
In some cases it would be nice to be able to control alignment of
the end labels. If labels are long they will stretch beyond the
borders of the sliders. This PR implements a way to avoid this by
introducing the `centerEndLabels` parameter. When this parameter is
false the first label will be left-aligned and the last label will
be right-aligned. Horizontal margin can be controlled by using the
new `horizontalMargin` parameter.